### PR TITLE
Handle async exceptions correctly in bracket and finally.

### DIFF
--- a/simple/src/Web/Simple/Controller/Exception.hs
+++ b/simple/src/Web/Simple/Controller/Exception.hs
@@ -9,16 +9,19 @@ onException act handler = control $ \runInM -> do
   runInM act `E.onException` runInM handler
 
 finally :: Controller s a -> Controller s b -> Controller s a
-finally act handler = do
-  res <- (act `onException` handler)
-  handler
-  return res
+finally act next = control $ \runInM -> E.mask $ \restore -> do
+  r <- restore (runInM act) `E.onException` (runInM next)
+  _ <- runInM next
+  return r
 
 bracket :: Controller s a -> (a -> Controller s b)
         -> (a -> Controller s c) -> Controller s c
-bracket aquire release act = do
-  a <- aquire
-  act a `finally` release a
+bracket aquire release act = control $ \runInM -> E.mask $ \restore -> do
+  let release' a = runInM $ restoreM a >>= release
+  a <- runInM aquire
+  r <- (restore $ runInM $ restoreM a >>= act) `E.onException` release' a
+  _ <- release' a
+  return r
 
 handle :: E.Exception e => (e -> Controller s a) -> Controller s a
        -> Controller s a


### PR DESCRIPTION
When I used the latest simple with povo ran into an issue where `withConnection` wasn't correctly running it's finally / bracket clause to return the connection back to the MVar. Investigating showed I needed to mask async exceptions for finally and bracket to behave as expected.
